### PR TITLE
revert: change outDir back to public for Render compatibility

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,6 @@ export default defineConfig({
     historyApiFallback: true, // ✅ Esta línea es la clave
   },
   build: {
-    outDir: "dist",
+    outDir: "public",
   },
 });


### PR DESCRIPTION
- Reverts build directory to public/ to maintain Render deployment compatibility
- Fixes authentication issues caused by build path changes
- Restores original working configuration

