### PR TITLE
fix: preserve database data by removing migration reset in build

### DIFF
--- a/render_build.sh
+++ b/render_build.sh
@@ -8,18 +8,7 @@ npm run build
 pip install pipenv
 pipenv install
 
-# Limpiar base de datos problemática en Render
-pipenv run python -c "
-import os
-from sqlalchemy import create_engine, text
-engine = create_engine(os.getenv('DATABASE_URL'))
-with engine.connect() as conn:
-    conn.execute(text('DROP TABLE IF EXISTS alembic_version'))
-    conn.commit()
-print('✅ Render database cleaned')
-"
+# Aplicar migraciones pendientes sin resetear la base de datos
+pipenv run flask db upgrade
 
-# Marcar nuestro baseline como aplicado
-pipenv run flask db stamp 7b25a2a2abae
-
-echo "✅ Migration baseline stamped"
+echo "✅ Migrations applied"


### PR DESCRIPTION
- Remove database cleaning script that was dropping alembic_version table
- Replace with standard flask db upgrade for production deployments
- This prevents data loss on each deployment to Render
- Migrations will now be applied incrementally without reset

